### PR TITLE
URLエンコードをRFC 3986に準拠するように修正

### DIFF
--- a/webapp/java/isuda/src/main/java/net/isucon6/qualify/service/EntryService.java
+++ b/webapp/java/isuda/src/main/java/net/isucon6/qualify/service/EntryService.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.HtmlUtils;
+import org.springframework.web.util.UriUtils;
 
 @Service
 public class EntryService {
@@ -61,7 +62,7 @@ public class EntryService {
                 String kw = e.getKey();
                 String hash = e.getValue();
                 String link = String.format("<a href=\"%s\">%s</a>",
-                        String.format("/keyword/%s", URLEncoder.encode(kw, "UTF-8")),
+                        String.format("/keyword/%s", UriUtils.encode(kw, "UTF-8")),
                         HtmlUtils.htmlEscape(kw, "UTF-8")
                 );
                 Matcher m = Pattern.compile(hash).matcher(result);


### PR DESCRIPTION
* 違いの例
  * 半角スペースが%20ではなく+になっていた
* 影響
  * 説明文中の別記事へのリンクを開いても該当記事が表示されない事がある
    * 半角スペースが記事タイトルに含まれている場合
  * ベンチマークのリンク有無の判定をPASSしないことがある
    * \<a>要素のhref属性の文字列が一致しているかで判断しているため